### PR TITLE
Removing demo role from edx_sandbox.yml

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -41,6 +41,7 @@
     - analytics_api
     - insights
     # not ready yet: - edx_notes_api
+    - { role: 'demo', tags: [ 'demo_course' ] }
     - oauth_client_setup
     - oraclejdk
     - role: elasticsearch

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -41,7 +41,6 @@
     - analytics_api
     - insights
     # not ready yet: - edx_notes_api
-    - demo
     - oauth_client_setup
     - oraclejdk
     - role: elasticsearch


### PR DESCRIPTION
Adding tag to the demo role in edx_sandbox.yml so that we can skip it with option "--skip-tags=demo_course" in ansible-playbook command in order to:
- demo course is not installed at all
- default accounts like staff@exmple.com not created at all

fullstack is still using vagrant-fullstack.yml which will have demo role and since it is kind of dev/test environment it is ok to keep it.

Note: I will also submit another PR to oxa-tools for skipping the demo role. We used demo_course as tag name since demo was already used as tag name.

@Microsoft/lex 