### PR TITLE
Disable wait_for task that fails to connect to Mongo replica set

### DIFF
--- a/playbooks/roles/forum/tasks/test.yml
+++ b/playbooks/roles/forum/tasks/test.yml
@@ -5,7 +5,8 @@
   with_items: forum_services
   when: not disable_edx_services
 
-- name: test that mongo replica set members are listing
-  wait_for: port={{ FORUM_MONGO_PORT }} host={{ item }} timeout=30
-  with_items: FORUM_MONGO_HOSTS
-  when: not disable_edx_services
+# OXA: disable wait_for which fails to detect our mongo replica set configured as "replicaSetName:ip1,ip2,ip3"
+#- name: test that mongo replica set members are listing
+#  wait_for: port={{ FORUM_MONGO_PORT }} host={{ item }} timeout=30
+#  with_items: FORUM_MONGO_HOSTS
+#  when: not disable_edx_services


### PR DESCRIPTION
@eltoncarr 