### PR TITLE
Plumb through config required for AzStorage support

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -737,6 +737,7 @@ generic_env_config:  &edxapp_generic_env
     STORAGE_TYPE: "{{ EDXAPP_GRADE_STORAGE_TYPE | default(None) }}"
     BUCKET: "{{ EDXAPP_GRADE_BUCKET | default(None) }}"
     ROOT_PATH: "{{ EDXAPP_GRADE_ROOT_PATH | default(None) }}"
+    CONTAINER: "{{ EDXAPP_GRADE_STORAGE_CONTAINER | default(None) }}"
   STATIC_URL_BASE: "{{ EDXAPP_STATIC_URL_BASE }}"
   STATIC_ROOT_BASE: "{{ edxapp_staticfile_dir }}"
   LMS_BASE: "{{ EDXAPP_LMS_BASE }}"


### PR DESCRIPTION
@btelnes @eltoncarr 

AzStorage support in platform didn't support standard EDXAPP_GRADE_STORAGE_KWARGS, so plumbing through CONTAINER config until we fix.