### PR TITLE
Adds security-related headers to J2 templates

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -36,10 +36,7 @@ error_page {{ k }} {{ v }};
 
   listen {{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
   {% endif %}
 
   # prevent the browser from doing MIME-type sniffing

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -39,11 +39,7 @@ error_page {{ k }} {{ v }};
   {% include "tls_harden.j2" %}
   {% endif %}
 
-  # prevent the browser from doing MIME-type sniffing
-  add_header X-Content-Type-Options nosniff;
-
-  # prevent potential XSS Reflection attack
-  add_header X-XSS-Protection "1; mode=block";
+  {% include "secure_headers.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -31,6 +31,8 @@ server {
   listen {{ CREDENTIALS_NGINX_PORT }} {{ default_site }};
   {% endif %}
 
+  {% include "secure_headers.j2" %}
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -25,10 +25,7 @@ server {
 
   {% include "common-settings.j2" %}
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
 
   {% else %}
   listen {{ CREDENTIALS_NGINX_PORT }} {{ default_site }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -26,10 +26,7 @@ server {
 
   {% include "common-settings.j2" %}
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
   {% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -29,6 +29,8 @@ server {
   {% include "tls_harden.j2" %}
   {% endif %}
 
+  {% include "secure_headers.j2" %}
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/harstorage.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/harstorage.j2
@@ -23,10 +23,7 @@ server {
   listen {{ HARSTORAGE_NGINX_PORT }} {{ default_site }};
   listen {{ HARSTORAGE_SSL_NGINX_PORT }} ssl;
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
 
   {% else %}
   listen {{ HARSTORAGE_NGINX_PORT }} {{ default_site }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -12,10 +12,7 @@ server {
 
   {% include "common-settings.j2" %}
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
   {% endif %}
 
   location ~ ^/static/(?P<file>.*) {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -12,10 +12,7 @@ server {
   {% if NGINX_ENABLE_SSL %}
   listen {{ EDXAPP_LMS_PREVIEW_SSL_NGINX_PORT }} ssl;
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
   {% endif %}
 
   # prevent the browser from doing MIME-type sniffing

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -15,11 +15,7 @@ server {
   {% include "tls_harden.j2" %}
   {% endif %}
 
-  # prevent the browser from doing MIME-type sniffing
-  add_header X-Content-Type-Options nosniff;
-
-  # prevent potential XSS Reflection attack
-  add_header X-XSS-Protection "1; mode=block";
+  {% include "secure_headers.j2" %}
   
   server_name preview.*;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -67,10 +67,7 @@ error_page {{ k }} {{ v }};
   {% if NGINX_ENABLE_SSL %}
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
   {% endif %}
 
   # prevent the browser from doing MIME-type sniffing

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -70,11 +70,7 @@ error_page {{ k }} {{ v }};
   {% include "tls_harden.j2" %}
   {% endif %}
 
-  # prevent the browser from doing MIME-type sniffing
-  add_header X-Content-Type-Options nosniff;
-
-  # prevent potential XSS Reflection attack
-  add_header X-XSS-Protection "1; mode=block";
+  {% include "secure_headers.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -26,10 +26,7 @@ server {
 
   listen {{ PROGRAMS_SSL_NGINX_PORT }} ssl;
 
-  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
-  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # Request that the browser use SSL for all connections.
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% include "tls_harden.j2" %}
 
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -4,12 +4,13 @@ add_header X-Content-Type-Options nosniff;
 # Prevent potential XSS Reflection attack
 add_header X-XSS-Protection "1; mode-block";
 
-# Allow any dynamic resources to load from the same origin.
+# Allow any dynamic resources to load from the same origin,
+# edx.org and microsoft.com.
 # Note that X-Content-Security-Policy is deprecated. The
 # Content-Security-Policy header value is currently a W3C
 # candidate recommendation but is supported within Edge,
 # Chrome, Firefox and Safari.
-add_header Content-Security-Policy "default-src 'self';";
+add_header Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com;";
 
 # Prevent click-jacking by disalowing pages from being
 # rendered within <frame>, <iframe> or <object>

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -4,13 +4,18 @@ add_header X-Content-Type-Options nosniff;
 # Prevent potential XSS Reflection attack
 add_header X-XSS-Protection "1; mode-block";
 
-# Allow any dynamic resources to load from the same origin,
-# edx.org and microsoft.com.
-# Note that X-Content-Security-Policy is deprecated. The
-# Content-Security-Policy header value is currently a W3C
-# candidate recommendation but is supported within Edge,
-# Chrome, Firefox and Safari.
-add_header Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com tags.tiqcdn.com az725175.vo.msecnd.net collect-us-east-1.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
+# Only allow resources to load from a specific set of
+# domains/subdomains required by Open edX.
+# Note that the Content-Security-Policy header value is currently
+# a W3C candidate recommendation and is supposedly supported
+# within Edge 15 build 15002+, Chrome 40+, Firefox 31+,
+# Safari 10+ and unsupported in all version of IE.  The previous
+# X-Content-Security-Policy header has been deprecated. However
+# Open edX does not render properly using Content-Security-Policy
+# whereas it does render as expected using X-Content-Security-Policy,
+# so we will leverage the older header until browser support catches
+# up with the standard.
+add_header X-Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
 
 # Prevent click-jacking by disalowing pages from being
 # rendered within <frame>, <iframe> or <object>

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -1,0 +1,16 @@
+# Prevent the browser from doing MIME-type sniffing
+add_header X-Content-Type-Options nosniff;
+
+# Prevent potential XSS Reflection attack
+add_header X-XSS-Protection "1; mode-block";
+
+# Allow any dynamic resources to load from the same origin.
+# Note that X-Content-Security-Policy is deprecated. The
+# Content-Security-Policy header value is currently a W3C
+# candidate recommendation but is supported within Edge,
+# Chrome, Firefox and Safari.
+add_header Content-Security-Policy "default-src 'self';";
+
+# Prevent click-jacking by disalowing pages from being
+# rendered within <frame>, <iframe> or <object>
+add_header X-Frame-Options SAMEORIGIN;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -10,7 +10,7 @@ add_header X-XSS-Protection "1; mode-block";
 # Content-Security-Policy header value is currently a W3C
 # candidate recommendation but is supported within Edge,
 # Chrome, Firefox and Safari.
-add_header Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com;";
+add_header Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com tags.tiqcdn.com az725175.vo.msecnd.net collect-us-east-1.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
 
 # Prevent click-jacking by disalowing pages from being
 # rendered within <frame>, <iframe> or <object>

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -1,22 +1,22 @@
-# Prevent the browser from doing MIME-type sniffing
-add_header X-Content-Type-Options nosniff;
+  # Prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
 
-# Prevent potential XSS Reflection attack
-add_header X-XSS-Protection "1; mode-block";
+  # Prevent potential XSS Reflection attack
+  add_header X-XSS-Protection "1; mode-block";
 
-# Only allow resources to load from a specific set of
-# domains/subdomains required by Open edX.
-# Note that the Content-Security-Policy header value is currently
-# a W3C candidate recommendation and is supposedly supported
-# within Edge 15 build 15002+, Chrome 40+, Firefox 31+,
-# Safari 10+ and unsupported in all version of IE.  The previous
-# X-Content-Security-Policy header has been deprecated. However
-# Open edX does not render properly using Content-Security-Policy
-# whereas it does render as expected using X-Content-Security-Policy,
-# so we will leverage the older header until browser support catches
-# up with the standard.
-add_header X-Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
+  # Only allow resources to load from a specific set of
+  # domains/subdomains required by Open edX.
+  # Note that the Content-Security-Policy header value is currently
+  # a W3C candidate recommendation and is supposedly supported
+  # within Edge 15 build 15002+, Chrome 40+, Firefox 31+,
+  # Safari 10+ and unsupported in all version of IE.  The previous
+  # X-Content-Security-Policy header has been deprecated. However
+  # Open edX does not render properly using Content-Security-Policy
+  # whereas it does render as expected using X-Content-Security-Policy,
+  # so we will leverage the older header until browser support catches
+  # up with the standard.
+  add_header X-Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
 
-# Prevent click-jacking by disalowing pages from being
-# rendered within <frame>, <iframe> or <object>
-add_header X-Frame-Options SAMEORIGIN;
+  # Prevent click-jacking by disalowing pages from being
+  # rendered within <frame>, <iframe> or <object>
+  add_header X-Frame-Options SAMEORIGIN;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/tls_harden.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/tls_harden.j2
@@ -1,0 +1,9 @@
+ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
+ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
+
+ssl_protocols TLSv1.1 TLSv1.2;
+ssl_ciphers 'ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA';
+ssl_prefer_server_ciphers on;
+
+# request the browser to use SSL for all connections
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";


### PR DESCRIPTION
#### What does this PR do? Please provide some context

Adds the following security-related headers:
• x-content-type-options: nosniff
• x-frame-options: SAMEORIGIN
• x-xss-protection: 1; mode=block
• x-content-security-policy (restricted to Open EdX required domains)

#### Where should the reviewer start?

secure_headers.j2

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

Install STAMP, navigate to LMS/CMS and view response headers within a network trace.

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )


Configuration Pull Request
---
#### (For changes proposed to upstream)
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
