### PR TITLE
Change npm registry to make it faster

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -50,7 +50,7 @@ COMMON_ENVIRONMENT: 'default_env'
 COMMON_DEPLOYMENT: 'default_deployment'
 COMMON_PIP_VERBOSITY: ''
 COMMON_PYPI_MIRROR_URL: 'https://pypi.python.org/simple'
-COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
+COMMON_NPM_MIRROR_URL: 'https://registry.npm.taobao.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"


### PR DESCRIPTION
Change npm registry to "https://registry.npm.taobao.org" which is located in China because the original one (https://registry.npmjs.org) may cause request timeout problem when deployed to mooncake.