### PR TITLE
All web pages that contain user-controllable content must opt-out of …

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -42,8 +42,11 @@ error_page {{ k }} {{ v }};
   
   {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
   # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
+  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}; includeSubDomains";
   {% endif %}
+
+  # prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -90,8 +90,11 @@ error_page {{ k }} {{ v }};
 
   {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
   # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
+  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}; includeSubDomains";
   {% endif %}
+
+  # prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';


### PR DESCRIPTION
What does this PR do? Please provide some context

Sends the X-Content-Type-Options response header with the value nosniff to prevent browsers from MIME-sniffing a response away from the declared content-type
Where should the reviewer start?

lms.j2, cms.j2, lms-preview.j2
How can this be manually tested? (brief repro steps)

Install OXA (devstack/fullstack), navigate to the LMS/CMS/preview site(s), then review the response headers for various files
What are the relevant TFS items? (list id numbers)

User Story 97860, Task 97923
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    This change has appropriate test coverage

Reminders BEFORE merging

    Get at least two approvals
    If you're merging from a feature branch into the development branch then "flatten" or "squash" commits
    If merging from the development branch into master (or porting changes from upstream) then use github's UI to get review feedback, but use the git command line interface to complete the actual merge.

Reminders AFTER merging

    Delete the remote feature branch
    Resolve relevant TFS items
    (reverse merge) If you merged from the development branch into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc). In this case, use github's UI for feedback and the git command line interface for the actual merge.

Configuration Pull Request
(For changes proposed to upstream)

Make sure that the following steps are done before merging

    @devops team member has commented with +1
    are you adding any new default values that need to be overridden when this goes live?
        Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
        Add an entry to the CHANGELOG.
