### PR TITLE
Adds security-related headers to J2 templates

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -19,6 +19,7 @@ NGINX_USERS:
 NGINX_ENABLE_SSL: False
 NGINX_REDIRECT_TO_HTTPS: False
 NGINX_HSTS_MAX_AGE: 31536000
+NGINX_X_CONTEXT_SECURITY_POLICY: "default-src 'self' *.edx.org *.{{ EDXAPP_SITE_NAME }} www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;"
 # Set these to real paths on your
 # filesystem, otherwise nginx will
 # use a self-signed snake-oil cert

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -40,10 +40,7 @@ error_page {{ k }} {{ v }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   {% endif %}
   
-  {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
-  {% endif %}
+  {% include "secure_headers.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -15,10 +15,7 @@ server {
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   {% endif %}
 
-  {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
-  {% endif %}
+  {% include "secure_headers.j2" %}
 
   {% include "common-settings.j2" %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -88,10 +88,7 @@ error_page {{ k }} {{ v }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   {% endif %}
 
-  {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
-  # request the browser to use SSL for all connections
-  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
-  {% endif %}
+  {% include ""secure_headers.j2 %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -1,0 +1,27 @@
+  {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}; includeSubDomains";
+  {% endif %}
+
+  # Prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
+
+  # Prevent potential XSS Reflection attack
+  add_header X-XSS-Protection "1; mode-block";
+
+  # Only allow resources to load from a specific set of
+  # domains/subdomains required by Open edX.
+  # Note that the Content-Security-Policy header value is currently
+  # a W3C candidate recommendation and is supposedly supported
+  # within Edge 15 build 15002+, Chrome 40+, Firefox 31+,
+  # Safari 10+ and unsupported in all version of IE.  The previous
+  # X-Content-Security-Policy header has been deprecated. However
+  # Open edX does not render properly using Content-Security-Policy
+  # whereas it does render as expected using X-Content-Security-Policy,
+  # so we will leverage the older header until browser support catches
+  # up with the standard.
+  add_header X-Content-Security-Policy "{{ NGINX_X_CONTEXT_SECURITY_POLICY }}";
+
+  # Prevent click-jacking by disalowing pages from being
+  # rendered within <frame>, <iframe> or <object>
+  add_header X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
What does this PR do? Please provide some context

Adds the following security-related headers:
• x-content-type-options: nosniff
• x-frame-options: SAMEORIGIN
• x-xss-protection: 1; mode=block
• x-content-security-policy (restricted to Open EdX required domains)
Where should the reviewer start?

secure_headers.j2
How can this be manually tested? (brief repro steps and corpnet-URL with change)

Install STAMP, navigate to LMS/CMS and view response headers within a network trace.
What are the relevant TFS items? (list id numbers)
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    This change has appropriate test coverage
    Get at least two approvals

Reminders DURING merge

    If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
    If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

Configuration Pull Request
(For changes proposed to upstream)

Make sure that the following steps are done before merging

    @devops team member has commented with +1
    are you adding any new default values that need to be overridden when this goes live?
        Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
        Add an entry to the CHANGELOG.
