### PR TITLE
Set limit_request_field_size to 0 within lms_gunicorn.py.j2 template …

### DIFF
--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -10,6 +10,15 @@ timeout = 300
 bind = "{{ edxapp_lms_gunicorn_host }}:{{ edxapp_lms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
 
+"""
+Setting limit_request_field_size to 0 will allow unlimited
+header field sizes.  This necessary to fix a bug where the
+header size is greater than 8190, the hard limit for headers
+in Gunicorn versions less than 19.7.0.  This shouldn't pose a
+security risk since Nginx restricts the header size to 16K.
+"""
+limit_request_field_size = 0
+
 {% if EDXAPP_LMS_MAX_REQ -%}
 max_requests = {{ EDXAPP_LMS_MAX_REQ }}
 {% endif -%}


### PR DESCRIPTION
What does this PR do? Please provide some context

Sets limit_request_field_size to 0 within lms_gunicorn.py to allow unlimited header field sizes. This is necessary to fix a bug where the header size is greater than 8190, the hard limit for headers in Gunicorn versions less than 19.7.0 (version used in Open Edx Ficus is 0.17.4). This shouldn't pose a security risk since Nginx acts as a proxy to Gunicorn and restricts the header size to 16K in nginx.conf.
Where should the reviewer start?

lms_gunicorn.py.j2
How can this be manually tested? (brief repro steps)

Using Postman or another tool, craft a request to the lms with large cookies such the the header is greater than 8190 bytes
What are the relevant TFS items? (list id numbers)

Bug 102507
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    This change has appropriate test coverage

Reminders BEFORE merging

    Get at least two approvals
    If you're merging from a feature branch into the development branch then "flatten" or "squash" commits
    If merging from the development branch into master (or porting changes from upstream) then use github's UI to get review feedback, but use the git command line interface to complete the actual merge.

Reminders AFTER merging

    Delete the remote feature branch
    Resolve relevant TFS items
    (reverse merge) If you merged from the development branch into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc). In this case, use github's UI for feedback and the git command line interface for the actual merge.

Configuration Pull Request
(For changes proposed to upstream)

Make sure that the following steps are done before merging

    @devops team member has commented with +1
    are you adding any new default values that need to be overridden when this goes live?
        Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
        Add an entry to the CHANGELOG.
