### PR TITLE
Add X-Content-Type-Options header which was missing for fonts

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -13,6 +13,9 @@
     location ~ ^/static/(?:.*)(?:\.xml|\.json|README.TXT) {
         return 403;
     }
+    
+    # Prevent the browser from doing MIME-type sniffing
+    add_header X-Content-Type-Options nosniff;
 
     # http://www.red-team-design.com/firefox-doesnt-allow-cross-domain-fonts-by-default
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -13,14 +13,15 @@
     location ~ ^/static/(?:.*)(?:\.xml|\.json|README.TXT) {
         return 403;
     }
-    
-    # Prevent the browser from doing MIME-type sniffing
-    add_header X-Content-Type-Options nosniff;
 
     # http://www.red-team-design.com/firefox-doesnt-allow-cross-domain-fonts-by-default
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {
         expires max;
         add_header Access-Control-Allow-Origin *;
+        
+        # Prevent the browser from doing MIME-type sniffing
+        add_header X-Content-Type-Options nosniff;
+    
         try_files /staticfiles/$collected /course_static/$collected =404;
     }
 


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Adds the X-Content-Type-Options header for font files.

#### Where should the reviewer start?
playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Deploy stamp and use a debugger to review the response headers for font files.

#### What are the relevant TFS items? (list id numbers)
104055

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )


Configuration Pull Request
---
#### (For changes proposed to upstream)
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
