### PR TITLE
Hawthorn: Remove 'Server' and 'X-Powered-By' headers for improved security 

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -82,9 +82,10 @@
     - install
     - install:system-requirements
 
+# Use the nginx-extras package for headers-more-nginx-module support 
 - name: Install the nginx package
   apt:
-    name: nginx
+    name: nginx-extras 
     state: latest
     update_cache: yes
   notify: restart nginx

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -21,7 +21,11 @@ http {
         # increase header buffer for for https://edx-wiki.atlassian.net/browse/LMS-467&gt
         # see http://orensol.com/2009/01/18/nginx-and-weird-400-bad-request-responses/
         large_client_header_buffers 4 16k;
-        # server_tokens off;
+        
+        # Remove server info for security
+        more_clear_headers 'Server';
+        more_clear_headers 'X-Powered-By';
+        server_tokens off;
 
         # server_names_hash_bucket_size 64;
         # server_name_in_redirect off;


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Removes 'Server' and 'X-Powered-By' headers for improved security.

#### Where should the reviewer start?
playbooks/roles/nginx/tasks/main.yml
playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Using Postman, Fiddler, or another tool, check the response headers to ensure that 'Server' and 'X-Powered-By' are not present.

#### What are the relevant TFS items? (list id numbers)
Bugs: 103444 & 103464
Task: 65315

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )


Configuration Pull Request
---
#### (For changes proposed to upstream)
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
