### PR TITLE
Hawthorn: Add security-related headers to secure_headers.j2 template 

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -177,3 +177,7 @@ NGINX_EDXAPP_CMS_APP_EXTRA: ""
 NGINX_EDXAPP_LMS_APP_EXTRA: ""
 
 NGINX_DJANGO_ADMIN_ACCESS_CIDRS: []
+
+NGINX_X_CONTENT_SECURITY_POLICY_HEADER: "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;"
+
+  

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -45,11 +45,7 @@ error_page {{ k }} {{ v }};
   add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
   {% endif %}
 
-  # prevent the browser from doing MIME-type sniffing
-  add_header X-Content-Type-Options nosniff;
-  
-  # prevent potential XSS Reflection attack
-  add_header X-XSS-Protection "1; mode=block"; 
+  {% include "secure_headers.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -45,6 +45,9 @@ error_page {{ k }} {{ v }};
   add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
   {% endif %}
 
+  # prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
+  
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -48,6 +48,9 @@ error_page {{ k }} {{ v }};
   # prevent the browser from doing MIME-type sniffing
   add_header X-Content-Type-Options nosniff;
   
+  # prevent potential XSS Reflection attack
+  add_header X-XSS-Protection "1; mode=block"; 
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -93,11 +93,7 @@ error_page {{ k }} {{ v }};
   add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
   {% endif %}
   
-  # prevent the browser from doing MIME-type sniffing
-  add_header X-Content-Type-Options nosniff; 
-
-  # prevent potential XSS Reflection attack
-  add_header X-XSS-Protection "1; mode=block";
+  {% include "secure_headers.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -96,6 +96,9 @@ error_page {{ k }} {{ v }};
   # prevent the browser from doing MIME-type sniffing
   add_header X-Content-Type-Options nosniff; 
 
+  # prevent potential XSS Reflection attack
+  add_header X-XSS-Protection "1; mode=block";
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -92,6 +92,9 @@ error_page {{ k }} {{ v }};
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
   {% endif %}
+  
+  # prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff; 
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -15,7 +15,7 @@
   # whereas it does render as expected using X-Content-Security-Policy,
   # so we will leverage the older header until browser support catches
   # up with the standard.
-  add_header X-Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
+  add_header X-Content-Security-Policy "{{ NGINX_X_CONTENT_SECURITY_POLICY_HEADER }}";
 
   # Prevent click-jacking by disalowing pages from being
   # rendered within <frame>, <iframe> or <object>

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/secure_headers.j2
@@ -1,0 +1,22 @@
+  # Prevent the browser from doing MIME-type sniffing
+  add_header X-Content-Type-Options nosniff;
+
+  # Prevent potential XSS Reflection attack
+  add_header X-XSS-Protection "1; mode-block";
+
+  # Only allow resources to load from a specific set of
+  # domains/subdomains required by Open edX.
+  # Note that the Content-Security-Policy header value is currently
+  # a W3C candidate recommendation and is supposedly supported
+  # within Edge 15 build 15002+, Chrome 40+, Firefox 31+,
+  # Safari 10+ and unsupported in all version of IE.  The previous
+  # X-Content-Security-Policy header has been deprecated. However
+  # Open edX does not render properly using Content-Security-Policy
+  # whereas it does render as expected using X-Content-Security-Policy,
+  # so we will leverage the older header until browser support catches
+  # up with the standard.
+  add_header X-Content-Security-Policy "default-src 'self' *.edx.org *.microsoft.com www.bing.com tags.tiqcdn.com az725175.vo.msecnd.net *.tealiumiq.com mscom.demdex.net googleads.g.doubleclick.net www.google.com;";
+
+  # Prevent click-jacking by disalowing pages from being
+  # rendered within <frame>, <iframe> or <object>
+  add_header X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Adds the following security-related headers:
• x-content-type-options: nosniff
• x-frame-options: SAMEORIGIN
• x-xss-protection: 1; mode=block
• x-content-security-policy (restricted to minimal set of required domains)

#### Where should the reviewer start?
Any of the files

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Deploy Hawthorn then check the headers using the client-side debugger, Fiddler, etc.

#### What are the relevant TFS items? (list id numbers)
Task 65465

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )


Configuration Pull Request
---
#### (For changes proposed to upstream)
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
