### PR TITLE
removed CA certs as it is no longer needed

### DIFF
--- a/playbooks/roles/notifier/tasks/main.yml
+++ b/playbooks/roles/notifier/tasks/main.yml
@@ -22,33 +22,6 @@
     state: present
   with_items: "{{ notifier_debian_pkgs }}"
 
-- name: Check if incommon ca is installed
-  command: "test -e /usr/share/ca-certificates/incommon/InCommonServerCA.crt"
-  register: incommon_present
-  ignore_errors: yes
-
-- name: Create incommon ca directory
-  file:
-    path: "/usr/share/ca-certificates/incommon"
-    state: directory
-    mode: "2775"
-  when: incommon_present|failed
-
-- name: Retrieve incommon server CA
-  get_url:
-    url: "https://www.incommon.org/cert/repository/InCommonServerCA.txt"
-    dest: "/usr/share/ca-certificates/incommon/InCommonServerCA.crt"
-  when: incommon_present|failed
-
-- name: Add InCommon ca cert
-  lineinfile:
-    dest: /etc/ca-certificates.conf
-    regexp: 'incommon/InCommonServerCA.crt'
-    line: 'incommon/InCommonServerCA.crt'
-
-- name: Update ca certs globally
-  shell: "update-ca-certificates"
-
 - name: Create notifier user {{ notifier_user }}
   user:
     name: "{{ notifier_user }}"


### PR DESCRIPTION
#### What does this PR do? Please provide some context
The ssl certificate on www.incommon.org has changed, causing the
certificate verification during deployment to fail. The certificate is
valid, but is based on a different (newer) chain of trust.

The second issue (which is hidden by the first), is that the server CA
url that is retrieved in this step is non-existent (404).
openedx already merged the PR to removed this piece of code as it is no longer required

https://github.com/edx/configuration/pull/5203

#### Where should the reviewer start?

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )


Configuration Pull Request
---
#### (For changes proposed to upstream)
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
